### PR TITLE
fix: intermediate question numbers updated in 001_operators_branching_loops.md

### DIFF
--- a/build-logic/001_operators_branching_loops.md
+++ b/build-logic/001_operators_branching_loops.md
@@ -18,7 +18,7 @@
 
 1. Fizzbuzz - Write a program to return an array from 1 to 100. But for every multiple of 3, replace the number with "Fizz", for every multiple of 5, replace the number with "Buzz" and for every multiples of 3 & 5, replace with "FizzBuzz".
 
-Your output should look something like this `1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17 ..... `
+    Your output should look something like this `1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17 ..... `
 
 1. Print the following star pattern :-
 


### PR DESCRIPTION
Fixes #8  .
Added white spaces before the text 
`Your output should look something like this 1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17 .....`